### PR TITLE
[codex] Implement contract intelligence chunks

### DIFF
--- a/.github/workflows/deploy-agent.yml
+++ b/.github/workflows/deploy-agent.yml
@@ -8,13 +8,37 @@ on:
       - "agents/**"
       - "shared/**"
       - ".github/workflows/deploy-agent.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "agents/**"
+      - "shared/**"
+      - ".github/workflows/deploy-agent.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  build:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    name: Build
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Build agents
+        run: dotnet build agents/agents.csproj --configuration Release
+
   build-and-deploy:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     name: Build and Deploy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,12 +17,9 @@ HQ Agent is the company headquarters platform. A modular Azure Static Web App wi
     /styles                  # app.css
 /api                         # SWA-managed HTTP functions — served at /api/* (C#, isolated worker)
   /Middleware                # RequireAccessMiddleware (auth on every HTTP request)
-/functions                   # Separate Azure Function App — background/event-driven only (C#, isolated worker)
-  /HqAgentFunctions          # Blob triggers, queue triggers, timer triggers — NOT browser-facing
-/agents                      # Agent projects — each agent is its own project
-  /contract-orchestrator-agent   # HTTP-triggered contract analysis (tool-use pipeline)
-  /contract-chat-agent           # (in progress)
-/shared                      # Shared C# library — referenced by api/, functions/, and agents/
+/agents                      # Standalone Azure Function App — agent HTTP + queue triggers (C#, isolated worker)
+  /Functions/Contract        # ContractIngestion, ContractChat, ContractOrchestratorAgent, ContractChatAgent
+/shared                      # Shared C# library — referenced by api/ and agents/
   /HqAgent.Shared            # HqAgent.Shared.csproj — targets net8.0 for SWA compatibility
   /HqAgent.Shared.Tests      # Unit tests for the shared library
 /infra                       # Infrastructure scripts and config
@@ -45,8 +42,8 @@ HQ Agent is the company headquarters platform. A modular Azure Static Web App wi
 
 - **Never duplicate** `BlobStorageService`, `TableStorageService`, `ExtractionResult`, or `ContractMessage` in any project — always reference shared.
 - `ExtractionResult` uses an open `Dictionary<string, JsonElement>` for extracted fields — no fixed schema. The model decides what fields are relevant.
-- `Contracts` stores both the full open extraction JSON and normalized query fields such as expiry date, notice deadline, counterparties, people, renewal status, assignment dates, and risk flags.
-- `TableStorageService.WriteExtractionAsync` automatically sets `status = "pending_review"` when `ExtractionResult.PendingReview = true`.
+- `Contracts` stores both the full open extraction JSON and normalized query fields such as expiry date, notice deadline, counterparties, people, renewal status, assignment dates, payment facts, review state, and risk flags.
+- `TableStorageService.WriteExtractionAsync` automatically sets `status = "pending_review"` and `ReviewState = "pending_review"` when `ExtractionResult.PendingReview = true`.
 
 ### CI/CD — shared triggers all three pipelines
 
@@ -55,8 +52,7 @@ A change to `shared/**` triggers **all** deployment workflows:
 | Workflow | Deploys | Triggered by |
 |---|---|---|
 | `deploy-frontend.yml` | `api/` + frontend | `frontend/**`, `api/**`, `shared/**` |
-| `deploy-functions.yml` | `functions/HqAgentFunctions` | `functions/**`, `shared/**` |
-| `deploy-agent.yml` | `agents/contract-orchestrator-agent` | `agents/contract-orchestrator-agent/**`, `shared/**` |
+| `deploy-agent.yml` | `agents/` standalone Function App | `agents/**`, `shared/**` |
 
 ## Azure Resources
 
@@ -81,32 +77,32 @@ If a task requires an architectural decision to proceed, stop and ask. Do not pi
 - **API (`/api/`)**: SWA-managed HTTP functions, C# isolated worker, currently `net8.0`. Deployed by the SWA workflow (`api_location: api`). Served at `/api/*`. HTTP triggers only — no blob/queue triggers here.
 - **Agents Function App (`/agents/`)**: Separate Azure Function App (`hq-agent-function-app`, Consumption plan), currently `net10.0` isolated worker. Background and agent-driven work only. Never called directly by the browser.
 - **No containers, no App Service, no Container Registry, no Dapr** — all agent logic runs as Azure Functions.
-- **Storage**: Azure Blob (contract files), Queue (work queue), Table (extracted data + alerts)
-- **Real-time**: WebSockets (NOT SignalR, NOT polling)
+- **Storage**: Azure Blob (contract files), Queue (work queue), Table (`Contracts`, `ContractChatHistory`)
+- **Status updates**: the frontend polls status for uploaded contracts.
 - **Queue**: Azure Queue Storage (NOT Service Bus)
 - **NO**: Containers, App Service, Container Registry, Dapr, Kubernetes, Logic Apps, Service Bus, SignalR
 
-### What goes where: api/ vs functions/
+### What goes where: api/ vs agents/
 
-| Belongs in `api/` | Belongs in `functions/` |
+| Belongs in `api/` | Belongs in `agents/` |
 |---|---|
-| Anything the browser calls (`/api/*`) | Blob triggers (e.g. new contract uploaded) |
-| Auth helpers (`GetConfig`, future session endpoints) | Queue triggers (e.g. contract processing) |
+| Anything the browser calls (`/api/*`) | Queue triggers (e.g. contract processing) |
+| Auth helpers (`GetConfig`, session endpoints) | Internal agent HTTP endpoints called by SWA `/api` |
 | Data read/write endpoints for the UI | Timer triggers |
 | File upload endpoints | Anything that runs in the background without a browser request |
 
-**Rule of thumb**: if the frontend JavaScript calls it, it goes in `api/`. If it reacts to a storage event or a queue message, it goes in `functions/`. Never put blob/queue triggers in `api/` and never put HTTP endpoints meant for the browser in `functions/`.
+**Rule of thumb**: if the frontend JavaScript calls it, it goes in `api/`. If it processes queue work or hosts internal agents, it goes in `agents/`. Never put queue triggers in SWA-managed `api/`, and never expose internal agent endpoints directly to the browser.
 
 ## AI Model Usage
 
 | Step | Model | Reason |
 |---|---|---|
-| Triage / classification | Claude Haiku 4.5 | Fastest, cheapest |
-| Contract extraction | Claude Sonnet 4.6 | Best default speed/quality |
-| Contract chat Q&A | Claude Sonnet 4.6 | Quality matters |
-| Escalation / second-pass | Claude Opus 4.6 | Fallback only |
+| PDF text extraction | `gpt-4.1-mini` | Cheap, fast, supports OpenAI file content |
+| Triage / classification | `gpt-4.1-mini` | Cheap, fast |
+| Contract extraction | `gpt-4.1` | Better extraction accuracy |
+| Contract chat Q&A | `gpt-4.1-mini` | Fast interactive chat with tools |
 
-Always use prompt caching for system prompts and extraction schemas. Use Message Batches API for bulk jobs.
+MAF handoff workflows use OpenAI only. Anthropic rejects the assistant-message prefill pattern that MAF handoff uses.
 
 ## App Settings
 
@@ -197,6 +193,9 @@ See [docs/MAF.md](./docs/MAF.md) for patterns, gotchas, and working examples cov
 - `ContractChatAgent` intentionally uses a direct OpenAI tool-calling loop for interactive chat, but its tools delegate to `IContractIntelligence` instead of owning storage queries directly.
 - `IContractIntelligence` is the internal capability layer future agents should call for contract questions such as expiring contracts, renewal windows, people/person impact, counterparty lookup, and document fallback.
 - `DocumentTextExtractor` is shared by ingestion and chat document fallback. It extracts PDF text through OpenAI file input and DOCX text locally from `word/document.xml`.
+- See [docs/contract-capabilities.md](./docs/contract-capabilities.md) for the durable fact model, review states, and cross-domain capability pattern.
+- See [docs/contracts-eval.md](./docs/contracts-eval.md) for the manual ingestion/chat evaluation checklist.
+- See [docs/operations.md](./docs/operations.md) for production health checks, Application Insights queries, and safe maintenance scripts.
 
 ## GitHub Workflows
 

--- a/agents/Functions/Contract/Agents/ContractChatAgent.cs
+++ b/agents/Functions/Contract/Agents/ContractChatAgent.cs
@@ -37,6 +37,7 @@ public class ContractChatAgent
         Use get_contract_document only when extracted fields lack the detail needed to answer the question.
 
         Answer accurately and concisely. Never hallucinate contract data, dates, parties, or clauses.
+        If a contract has reviewState pending_review, say that the extracted data needs review when it affects the answer.
         If you cannot find the answer in the available data, say so clearly.
         """;
 
@@ -44,7 +45,7 @@ public class ContractChatAgent
     [
         ChatTool.CreateFunctionTool(
             "list_contracts",
-            "List all contracts accessible to the current user with normalized metadata, dates, parties, people, and risk flags.",
+            "List all contracts accessible to the current user with normalized metadata, dates, parties, people, payment terms, review state, and risk flags.",
             BinaryData.FromString("""{"type":"object","properties":{},"required":[]}""")),
         ChatTool.CreateFunctionTool(
             "find_expiring_contracts",
@@ -60,7 +61,7 @@ public class ContractChatAgent
             BinaryData.FromString("""{"type":"object","properties":{"personName":{"type":"string","description":"The person name to search for"}},"required":["personName"]}""")),
         ChatTool.CreateFunctionTool(
             "find_contracts_by_counterparty",
-            "Find contracts by customer, supplier, vendor, client, or other counterparty name.",
+            "Find contracts by customer, supplier, vendor, client, or other counterparty name. Results include normalized payment facts when available.",
             BinaryData.FromString("""{"type":"object","properties":{"counterparty":{"type":"string","description":"The counterparty name to search for"}},"required":["counterparty"]}""")),
         ChatTool.CreateFunctionTool(
             "get_contract",

--- a/agents/Functions/Contract/Agents/ContractOrchestratorAgent.cs
+++ b/agents/Functions/Contract/Agents/ContractOrchestratorAgent.cs
@@ -56,7 +56,8 @@ public class ContractOrchestratorAgent
         Extract the fields that are relevant for this specific document type — do not use a fixed schema.
         Common fields: parties (array), effectiveDate (ISO 8601), expiryDate (ISO 8601),
         noticePeriodDays (integer), governingLaw, keyObligations (array), autoRenewal (boolean),
-        riskFlags (array) — include whatever is most relevant for this document.
+        riskFlags (array), paymentAmount (number), paymentCurrency, paymentUnit, paymentType,
+        paymentTerms — include whatever is most relevant for this document.
 
         For consulting agreements, prioritize: customer/client, supplier/vendor, consultantNames,
         assignmentTitle, assignmentDescription, assignmentStartDate, assignmentEndDate, workloadPercent,
@@ -66,6 +67,21 @@ public class ContractOrchestratorAgent
         For NDAs, prioritize: parties, mutualOrOneWay, effectiveDate, expiryDate,
         confidentialityPeriod, survivalPeriod, purpose, permittedDisclosures,
         returnOrDestructionObligation, governingLaw, jurisdiction, signatories.
+
+        For software licences, prioritize: customer/licensee, supplier/licensor, productName,
+        licenceMetric, seatCount, licenceStartDate, licenceEndDate, renewalTerms,
+        paymentAmount, paymentCurrency, paymentUnit, paymentType, supportTerms, auditRights.
+
+        For service/customer agreements, prioritize: customer/client, supplier/vendor,
+        serviceDescription, serviceStartDate, serviceEndDate, serviceLevels, renewalTerms,
+        terminationTerms, paymentAmount, paymentCurrency, paymentUnit, paymentType, paymentTerms.
+
+        For one-time engagements, prioritize: customer/client, supplier/vendor, eventDate,
+        serviceDescription, peopleMentioned, paymentAmount, paymentCurrency, paymentUnit,
+        paymentType, paymentTerms, cancellationTerms.
+
+        Set pendingReview to true if the document type is ambiguous, extraction confidence is below 0.75,
+        dates or parties conflict, payment facts conflict, or a core field for the document type is missing.
 
         Output ONLY this JSON object, no markdown, no code fences, no other text:
         {

--- a/agents/Functions/Contract/Services/ContractIntelligence.cs
+++ b/agents/Functions/Contract/Services/ContractIntelligence.cs
@@ -178,8 +178,16 @@ public class ContractIntelligence : IContractIntelligence
             e.CustomerName,
             e.AssignmentStartDate,
             e.AssignmentEndDate,
+            e.PaymentAmount,
+            e.PaymentCurrency,
+            e.PaymentUnit,
+            e.PaymentType,
+            e.PaymentTerms,
             ParseJsonList(e.RiskFlags),
-            ParseJsonList(e.MissingFields));
+            ParseJsonList(e.MissingFields),
+            string.IsNullOrWhiteSpace(e.ReviewState)
+                ? (e.Status == "pending_review" ? "pending_review" : "approved_by_extraction")
+                : e.ReviewState);
 
     private static IReadOnlyList<string> ParseJsonList(string json)
     {

--- a/agents/Functions/Contract/Services/ContractIntelligenceModels.cs
+++ b/agents/Functions/Contract/Services/ContractIntelligenceModels.cs
@@ -30,8 +30,14 @@ public record ContractSummary(
     string CustomerName,
     DateTime? AssignmentStartDate,
     DateTime? AssignmentEndDate,
+    double? PaymentAmount,
+    string PaymentCurrency,
+    string PaymentUnit,
+    string PaymentType,
+    string PaymentTerms,
     IReadOnlyList<string> RiskFlags,
-    IReadOnlyList<string> MissingFields);
+    IReadOnlyList<string> MissingFields,
+    string ReviewState);
 
 public record ContractDetail(
     ContractSummary Summary,

--- a/api/GetContract.cs
+++ b/api/GetContract.cs
@@ -95,8 +95,22 @@ public class GetContract
                 entity.CustomerName,
                 entity.AssignmentStartDate,
                 entity.AssignmentEndDate,
+                entity.PaymentAmount,
+                entity.PaymentCurrency,
+                entity.PaymentUnit,
+                entity.PaymentType,
+                entity.PaymentTerms,
                 riskFlags = JsonList(entity.RiskFlags),
                 missingFields = JsonList(entity.MissingFields),
+            },
+            review = new
+            {
+                state = string.IsNullOrWhiteSpace(entity.ReviewState)
+                    ? (entity.Status == "pending_review" ? "pending_review" : "approved_by_extraction")
+                    : entity.ReviewState,
+                entity.ReviewedAt,
+                entity.ReviewedBy,
+                entity.ReviewNote,
             },
             fields,
         });

--- a/api/ListContracts.cs
+++ b/api/ListContracts.cs
@@ -58,6 +58,16 @@ public class ListContracts
             customerName  = e.CustomerName,
             assignmentStartDate = e.AssignmentStartDate,
             assignmentEndDate = e.AssignmentEndDate,
+            paymentAmount = e.PaymentAmount,
+            paymentCurrency = e.PaymentCurrency,
+            paymentUnit = e.PaymentUnit,
+            paymentType = e.PaymentType,
+            paymentTerms = e.PaymentTerms,
+            reviewState = string.IsNullOrWhiteSpace(e.ReviewState)
+                ? (e.Status == "pending_review" ? "pending_review" : "approved_by_extraction")
+                : e.ReviewState,
+            reviewedAt = e.ReviewedAt,
+            reviewedBy = e.ReviewedBy,
         });
 
         var res = req.CreateResponse();

--- a/api/ReviewContract.cs
+++ b/api/ReviewContract.cs
@@ -1,0 +1,106 @@
+using System.Net;
+using System.Text.Json;
+using HqAgent.Shared.Storage;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Configuration;
+
+namespace HqAgent.Api;
+
+/// <summary>
+/// Updates the human review state for an extracted contract.
+/// POST /api/review-contract
+/// Body: { "correlationId": "...", "reviewState": "approved", "reviewNote": "optional" }
+/// </summary>
+public class ReviewContract
+{
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly TableStorageService _table;
+    private readonly string _appId;
+
+    public ReviewContract(IHttpClientFactory httpFactory, TableStorageService table, IConfiguration config)
+    {
+        _httpFactory = httpFactory;
+        _table       = table;
+        _appId       = config["APP_ID"] ?? "hqagents";
+    }
+
+    [Function("ReviewContract")]
+    public async Task<HttpResponseData> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "review-contract")] HttpRequestData req,
+        FunctionContext context)
+    {
+        RoleGuard guard;
+        try { guard = await RoleGuard.CheckAsync(req, _httpFactory, _appId, Roles.Admin); }
+        catch { return await PlainResponse(req, HttpStatusCode.ServiceUnavailable, "Auth service unavailable"); }
+
+        if (!guard.Allowed)
+            return await PlainResponse(req, HttpStatusCode.Forbidden, "Forbidden");
+
+        ReviewContractRequest? body;
+        try
+        {
+            body = await JsonSerializer.DeserializeAsync<ReviewContractRequest>(
+                req.Body,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        }
+        catch (JsonException)
+        {
+            return await PlainResponse(req, HttpStatusCode.BadRequest, "Invalid JSON body");
+        }
+
+        if (string.IsNullOrWhiteSpace(body?.CorrelationId))
+            return await PlainResponse(req, HttpStatusCode.BadRequest, "correlationId is required");
+
+        var reviewState = NormalizeReviewState(body.ReviewState);
+        if (reviewState is null)
+            return await PlainResponse(req, HttpStatusCode.BadRequest, "reviewState must be approved or pending_review");
+
+        var userId = context.Items.TryGetValue("userId", out var uid) ? uid?.ToString() ?? "" : "";
+        var entity = await _table.UpdateReviewAsync(
+            body.CorrelationId,
+            reviewState,
+            userId,
+            body.ReviewNote,
+            context.CancellationToken);
+
+        if (entity is null)
+            return await PlainResponse(req, HttpStatusCode.NotFound, "Not found");
+
+        var res = req.CreateResponse();
+        await res.WriteAsJsonAsync(new
+        {
+            correlationId = entity.PartitionKey,
+            status = entity.Status,
+            reviewState = entity.ReviewState,
+            reviewedAt = entity.ReviewedAt,
+            reviewedBy = entity.ReviewedBy,
+        });
+        res.StatusCode = HttpStatusCode.OK;
+        return res;
+    }
+
+    private static string? NormalizeReviewState(string? reviewState) =>
+        reviewState?.Trim().ToLowerInvariant() switch
+        {
+            "approved" => "approved",
+            "pending_review" => "pending_review",
+            "pending-review" => "pending_review",
+            "needs_review" => "pending_review",
+            _ => null,
+        };
+
+    private static async Task<HttpResponseData> PlainResponse(
+        HttpRequestData req, HttpStatusCode status, string message)
+    {
+        var res = req.CreateResponse();
+        await res.WriteStringAsync(message);
+        res.StatusCode = status;
+        return res;
+    }
+}
+
+public record ReviewContractRequest(
+    string CorrelationId,
+    string ReviewState,
+    string? ReviewNote);

--- a/azure-resources.md
+++ b/azure-resources.md
@@ -3,52 +3,136 @@
 **Subscription:** Be Concrete Main (`e70b3a39-d6a6-43c9-9c42-90bb2ed1a393`)
 **Resource Group:** `hq-agent-resource-group`
 **Primary Location:** northeurope
-**Last updated:** 2026-04-19 (issue #24 pending)
+**Last verified:** 2026-04-21 using `az`
 
 ## Resources
 
 | Resource | Name | Type | Location | Notes |
 |---|---|---|---|---|
 | Resource Group | `hq-agent-resource-group` | Microsoft.Resources/resourceGroups | northeurope | Primary resource group |
-| Storage Account | `hqagentstorage` | Microsoft.Storage/storageAccounts | northeurope | Blob (contracts), Queue (work queue), Table (extracted data + alerts) |
-| Static Web App | `hq-agent-static-web-app` | Microsoft.Web/staticSites | westeurope | SWA only available in westeurope for EU. CDN-distributed globally. URL: `wonderful-ground-0acacb103.7.azurestaticapps.net` |
-| Function App | `hq-agent-function-app` | Microsoft.Web/sites | northeurope | C# isolated worker, .NET 10, Consumption plan (Y1). Hosts the agent functions in `agents/`. |
-| Function App Plan | `NorthEuropePlan` | Microsoft.Web/serverFarms | northeurope | Consumption (Y1) — auto-created with `hq-agent-function-app` |
-| Application Insights | `hq-agent-function-app` | microsoft.insights/components | northeurope | Auto-created with Function App |
+| Storage Account | `hqagentstorage` | Microsoft.Storage/storageAccounts | northeurope | Blob, Queue, and Table storage for contracts and Function runtime state |
+| Static Web App | `hq-agent-static-web-app` | Microsoft.Web/staticSites | westeurope | Hosts the Vue frontend and SWA-managed `/api`. Default URL: `wonderful-ground-0acacb103.7.azurestaticapps.net` |
+| Agents Function App | `hq-agent-function-app` | Microsoft.Web/sites | northeurope | Standalone Azure Functions app for contract agents. C# isolated worker, Functions v4, .NET 10 |
+| Function App Plan | `NorthEuropePlan` | Microsoft.Web/serverFarms | northeurope | Windows Consumption plan (Y1). Hosts `hq-agent-function-app` |
+| Application Insights | `hq-agent-function-app` | Microsoft.Insights/components | northeurope | Telemetry for `hq-agent-function-app` |
 
-## Storage Containers / Queues / Tables
+## Storage
 
-| Type | Name | Purpose |
-|---|---|---|
-| Blob Container | `contracts` | Uploaded contract files (PDF, DOCX) |
-| Queue | `contract-processing` | Work queue — ContractIngestion function reads from here |
-| Queue | `contract-completed` | Completion notifications — written after processing, consumed by WebSocket handler (future) |
-| Table | `Contracts` | Contract records with open extraction JSON plus normalized query fields (dates, parties, people, renewal, risk), `status` is `completed` or `pending_review` |
-| Table | `ContractAlerts` | Contract expiry alerts — written by timer function, read by /api/contract-alerts |
+### Blob Containers
 
-## Ingestion flow
+| Container | Purpose |
+|---|---|
+| `contracts` | Uploaded contract files at `contracts/{correlationId}/{fileName}` |
+| `azure-webjobs-hosts` | Azure Functions runtime state |
+| `azure-webjobs-secrets` | Azure Functions host/function keys |
+| `scm-releases` | Deployment/runtime artifact storage |
+
+### Queues
+
+| Queue | Purpose |
+|---|---|
+| `contract-processing` | Work queue. SWA `/api/upload-contract` writes `ContractMessage`; `ContractIngestion` consumes it |
+| `contract-processing-poison` | Azure Functions poison queue for failed `contract-processing` messages |
+
+### Tables
+
+| Table | Purpose |
+|---|---|
+| `Contracts` | Contract records with original extraction JSON plus normalized query fields such as dates, counterparties, people, renewal, assignment, payment, risk, status, blob path, owner, and visibility |
+| `ContractChatHistory` | Contract chat turns stored by `ContractChatAgent` per chat session |
+
+## Runtime Split
+
+| Area | Hosted By | Runtime | Deployment |
+|---|---|---|---|
+| Frontend | Azure Static Web Apps | Vue/Vite static assets | `.github/workflows/deploy-frontend.yml` |
+| Browser API (`/api/*`) | SWA-managed Azure Functions from `api/` | C# isolated worker, `net8.0` | `.github/workflows/deploy-frontend.yml` with `api_location: api` |
+| Contract agents | `hq-agent-function-app` from `agents/` | C# isolated worker, `net10.0`, Functions v4 | `.github/workflows/deploy-agent.yml` |
+| Shared library | `shared/HqAgent.Shared` | `net8.0` | Referenced by both `api/` and `agents/`; agents can consume the `net8.0` assembly from .NET 10 |
+
+`api/` intentionally stays on `net8.0` because Azure Static Web Apps managed Functions currently do not support .NET 10. We are staying with SWA-managed `/api`, so this runtime split is intentional.
+
+## App Settings
+
+### Static Web App
+
+Production SWA app settings include:
+
+| Setting | Purpose |
+|---|---|
+| `APP_ID` | Be Concrete app identifier (`hqagents`) |
+| `STORAGE_CONNECTION_STRING` | Access to `hqagentstorage` for uploads, tables, and queues |
+| `CHAT_AGENT_BASE_URL` | Base URL for `hq-agent-function-app` |
+| `CHAT_AGENT_KEY` | Function key used by the SWA `/api/contract-chat` proxy |
+
+### Agents Function App
+
+Production Function App settings include:
+
+| Setting | Purpose |
+|---|---|
+| `FUNCTIONS_EXTENSION_VERSION` | Functions runtime, currently `~4` |
+| `FUNCTIONS_WORKER_RUNTIME` | `dotnet-isolated` |
+| `WEBSITE_USE_PLACEHOLDER_DOTNETISOLATED` | Cold-start optimization for isolated .NET Functions |
+| `APP_ID` | Be Concrete app identifier (`hqagents`) |
+| `STORAGE_CONNECTION_STRING` | Access to `hqagentstorage` for contract blobs, queues, and tables |
+| `AzureWebJobsStorage` | Azure Functions runtime storage |
+| `OPENAI_API_KEY` | OpenAI API key for `ContractChatAgent` |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | Telemetry connection for Application Insights |
+
+## Production Flows
+
+### Upload And Ingestion
 
 ```
-Frontend → POST /api/upload-contract
-  → [SWA /api/] uploads blob to hqagentstorage/contracts/{correlationId}/{name}
-  → sends ContractMessage to contract-processing queue          ← pending issue #24
-                                                                   (today: BlobTrigger does this)
-  → returns 200 { correlationId }
+Frontend
+  → POST /api/upload-contract
+  → [SWA-managed api/UploadContract]
+      - validates caller/admin role
+      - uploads file to hqagentstorage/contracts/{correlationId}/{fileName}
+      - writes ContractMessage to hqagentstorage/contract-processing
+      - returns { correlationId, blobName, fileName, status: "processing" }
 
-  → [hq-agent-function-app] ContractIngestion queue trigger fires
-  → triage (fast model) + extraction (quality model)
-  → writes contract record / ExtractionResult + normalized facts to Contracts table
-  → sends completion notification to contract-completed queue
+  → [hq-agent-function-app / ContractIngestion]
+      - queue trigger reads contract-processing
+      - ContractOrchestratorAgent triages and extracts facts
+      - writes result to Contracts table
 ```
+
+There is no active `contract-completed` queue in production.
+
+### Contract Chat
+
+```
+Frontend
+  → POST /api/contract-chat
+  → [SWA-managed api/ContractChat]
+      - validates caller/user role
+      - forwards identity headers to hq-agent-function-app
+      - calls /api/contract-chat using CHAT_AGENT_KEY
+
+  → [hq-agent-function-app / ContractChat]
+      - ContractChatAgent answers using contract tools
+      - reads Contracts table and contract blobs as needed
+      - writes chat turns to ContractChatHistory
+      - returns answer plus contract references
+```
+
+## Functions In Production
+
+`hq-agent-function-app` currently exposes:
+
+| Function | Trigger | Route/Queue | Entry Point |
+|---|---|---|---|
+| `ContractChat` | HTTP trigger, function auth | `POST /api/contract-chat` | `HqAgent.Agents.Contract.Triggers.ContractChatFunction.Run` |
+| `ContractIngestion` | Queue trigger | `contract-processing` | `HqAgent.Agents.Contract.Triggers.ContractIngestion.Run` |
 
 ## Notable Decisions
 
-- **No containers, no App Service, no Container Registry, no Dapr** — all deleted 2026-04-17. All agent logic runs as Azure Functions on the Consumption plan using native queue/blob bindings.
-- **API enqueues directly (pending issue #24)** — after issue #24, `UploadContract` sends the queue message itself. Until then, `ContractBlobTrigger` handles this via blob-event polling.
-- **`hq-agent-function-app` hosts `functions/HqAgentFunctions`** — queue trigger for contract ingestion pipeline. Blob trigger will be removed in issue #24.
-- **One Function App for everything** — both `functions/HqAgentFunctions` and `agents/` deploy to `hq-agent-function-app`. This may be split in the future but requires an explicit architectural decision.
-- **Shared library `HqAgent.Shared`** — targets `net8.0` for SWA-managed API compatibility. The standalone `agents/` Function App targets `net10.0` and references the shared `net8.0` library. Contains `BlobStorageService`, `TableStorageService`, `ContractMessage`, `ExtractionResult`, and normalized contract fact helpers.
-- **Runtime split** — `api/` stays on `net8.0` because Azure Static Web Apps managed Functions currently support up to .NET 9 isolated, not .NET 10. `agents/` runs on `net10.0` in the standalone Azure Function App.
-- **SWA uses westeurope** — Azure Static Web Apps are not available in northeurope. Content is CDN-distributed so latency for end users is unaffected.
-- **Function App uses Consumption plan** — scales to zero, ~$0-2/month at low volume.
-- **`AzureWebJobsStorage`** — required by the Functions runtime (lease containers, distributed locks). Does not need to match `hqagentstorage`. After issue #24 removes the BlobTrigger, this setting is purely an internal runtime concern.
+- **SWA-managed `/api` stays** — browser-facing endpoints remain in the Static Web App managed Functions model.
+- **Agents are separate** — agent runtime is hosted in `hq-agent-function-app` so it can run .NET 10 and long-lived agent dependencies without forcing SWA `/api` off its supported runtime.
+- **No active blob-trigger ingestion** — uploads enqueue directly from `api/UploadContract`; ingestion is queue-triggered.
+- **No active alert timer resources** — `ContractAlerts` is not present in production storage.
+- **Unused Azure resources removed** — `NorthEuropeLinuxDynamicPlan`, the orphaned `hq-agent-orchestrator-app` Application Insights component, and the old `azure-webjobs-blobtrigger-hq-agent-function-app` queue were deleted on 2026-04-21.
+- **No containers, App Service web apps, Container Registry, Dapr, Kubernetes, Logic Apps, Service Bus, or SignalR** are part of the current production runtime.
+- **Storage table name is `Contracts`** — the old `ContractExtractions` name is no longer used.

--- a/docs/MAF.md
+++ b/docs/MAF.md
@@ -93,7 +93,7 @@ private static string ExtractOutermostJson(string text)
 
 `TryExtractJsonAt` counts braces to find the balanced end of a JSON object. The outer loop tries each `{` in order. The first one that is both brace-balanced AND parses as valid JSON is the outermost result object.
 
-See `agents/contract-orchestrator-agent/Services/OpenAIContractWorkflow.cs` for the full implementation.
+See `agents/Functions/Contract/Agents/ContractOrchestratorAgent.cs` for the full implementation.
 
 ---
 
@@ -202,6 +202,18 @@ public async Task<ExtractionResult> RunAsync(ContractMessage msg, CancellationTo
 
 The `IChatClient` instances (`_triageChatClient`, `_extractionChatClient`) can be long-lived singletons — only the workflow and agents need to be scoped per invocation.
 
+## Checklist for a new MAF workflow
+
+- Keep the workflow bounded and job-like. Use MAF when handoff between specialist agents adds value.
+- Use OpenAI chat clients; do not introduce Anthropic for handoff workflows.
+- Create agents and `AgentWorkflowBuilder` inside the invocation so history is isolated per job.
+- Use a stable `sessionId`, normally the job correlation ID.
+- Emit a single parseable JSON object for structured jobs.
+- Parse the first brace-balanced JSON object, not the last nested object.
+- Keep the `MAAIW001` suppression around `AgentWorkflowBuilder` handoff code.
+- Add a unit test for any parser/normalizer that consumes workflow output.
+- Document the new workflow in this file before adding future domains.
+
 ---
 
 ## Agent registration — no interface needed for single implementations
@@ -210,10 +222,10 @@ If there is only one implementation of a workflow service, register it directly 
 
 ```csharp
 // Program.cs
-services.AddSingleton<OpenAIContractWorkflow>();
+services.AddSingleton<ContractOrchestratorAgent>();
 
 // ContractIngestion.cs
-public ContractIngestion(OpenAIContractWorkflow workflow, ...)
+public ContractIngestion(ContractOrchestratorAgent orchestrator, ...)
 ```
 
 ---

--- a/docs/contract-capabilities.md
+++ b/docs/contract-capabilities.md
@@ -1,0 +1,97 @@
+# Contract Capabilities
+
+This document describes the Contracts domain boundary as it exists today and the shape future agents should depend on.
+
+## Durable Fact Model
+
+The `Contracts` table stores one row per uploaded contract. Raw extraction remains available in `Fields`, while common query facts are promoted to columns so chat, lifecycle views, and future agents can answer without scraping model JSON.
+
+| Area | Fields |
+|---|---|
+| Identity | `PartitionKey` correlation ID, `BlobPath`, `FileName`, `UserId`, `UploadedAt`, `DocumentType` |
+| Confidence | `TriageConfidence`, `ExtractionConfidence`, `ModelUsed`, `Status`, `ReviewState` |
+| Dates | `EffectiveDate`, `ExpiryDate`, `NoticePeriodDays`, `NoticeDeadline`, `AutoRenewal` |
+| Parties and people | `PrimaryCounterparty`, `CounterpartyNames`, `PeopleMentioned`, `CustomerName` |
+| Assignment | `AssignmentStartDate`, `AssignmentEndDate` |
+| Commercials | `PaymentAmount`, `PaymentCurrency`, `PaymentUnit`, `PaymentType`, `PaymentTerms` |
+| Quality | `RiskFlags`, `MissingFields`, `ReviewedAt`, `ReviewedBy`, `ReviewNote` |
+
+The supported first-pass contract families are NDA, consulting assignment, software/licence, service/customer agreement, and one-time engagement. Family-specific details that are not used for portfolio queries stay in `Fields`.
+
+## Review States
+
+`Status` controls coarse UI behavior:
+
+| Status | Meaning |
+|---|---|
+| `processing` | Uploaded and queued, not extracted yet |
+| `completed` | Extracted and usable |
+| `pending_review` | Extracted but core facts are missing, ambiguous, or low confidence |
+| `failed` | Ingestion failed |
+
+`ReviewState` is the human review layer:
+
+| ReviewState | Meaning |
+|---|---|
+| `approved_by_extraction` | Model extraction was confident enough to use without manual review |
+| `pending_review` | Admin should inspect the row before relying on it |
+| `approved` | Admin approved the extracted facts |
+| `failed` | No usable extraction exists |
+
+Approving a contract stores `ReviewedAt`, `ReviewedBy`, and optional `ReviewNote`. Raw extraction is not overwritten by approval.
+
+## Capability Boundary
+
+`IContractIntelligence` is the internal boundary for contract-domain facts. Future agents should call this interface instead of table storage, blob storage, or `ContractChatAgent`.
+
+Deterministic methods:
+
+| Method | Use |
+|---|---|
+| `ListContractsAsync` | Portfolio overview with normalized facts |
+| `GetContractAsync` | Detail for a known correlation ID |
+| `GetContractDocumentTextAsync` | Document fallback when extracted facts are insufficient |
+| `FindExpiringAsync` | Expiry queries by date range and optional type |
+| `FindRenewalWindowsAsync` | Notice/renewal/action deadline queries |
+| `FindByPersonAsync` | Employee, consultant, signatory, or contact impact |
+| `FindByCounterpartyAsync` | Customer, supplier, vendor, or party lookup |
+
+Conversational method:
+
+| Method | Use |
+|---|---|
+| `AnswerAsync` | A lightweight contract-domain answer wrapper. Use deterministic methods first when another agent already knows what it needs. |
+
+`ContractChatAgent` is a frontend conversation layer over this boundary. It may use model tool-calling and document fallback, but that should not become the integration contract for future Sales or HR agents.
+
+## Cross-Domain Invocation Pattern
+
+For the next domains, use domain capabilities directly in-process when the caller is hosted inside `hq-agent-function-app`. Do not expose internal agent endpoints to the browser.
+
+Minimum request context:
+
+| Field | Purpose |
+|---|---|
+| `Caller.UserId` | Ownership and audit trail |
+| `Caller.IsAdmin` | Visibility boundary |
+| `CorrelationId` | Traceability across agents and logs |
+| `SourceAgent` | Example: `SalesForecastAgent` |
+| `QuestionIntent` | Why the other domain is being called |
+
+Minimum response behavior:
+
+- Return normalized facts and source references, not prose only.
+- Preserve document correlation IDs when a contract influenced the answer.
+- Log the calling agent, target capability, and correlation ID.
+- Avoid letting future domains depend on `ContractExtractionEntity` internals.
+
+Example future Sales call:
+
+```csharp
+var expiringAssignments = await contracts.FindExpiringAsync(
+    caller,
+    from: DateOnly.FromDateTime(DateTime.UtcNow),
+    to: DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(6)),
+    contractType: "consulting",
+    ct);
+```

--- a/docs/contracts-eval.md
+++ b/docs/contracts-eval.md
@@ -1,0 +1,44 @@
+# Contracts Evaluation Set
+
+Use this checklist after extraction or chat changes. The current fixtures live in `infra/test/`.
+
+## Fixture Coverage
+
+| Fixture | Expected family | Purpose |
+|---|---|---|
+| `nda-microsoft-sweden-be-concrete.pdf` | NDA | Counterparty lookup and confidentiality facts |
+| `nda-aws-sweden-be-concrete.pdf` | NDA | Second NDA counterparty |
+| `consulting-spotify-solutions-architect-bjorn-jan-feb-2026.pdf` | Consulting assignment | Easy assignment, expiry, person, hourly rate |
+| `consulting-lovable-platform-architecture-bjorn-may-dec-2026.pdf` | Consulting assignment | More complex assignment and longer lifecycle |
+| `inspirational-talk-nox-consulting-bjorn-2026.pdf` | One-time engagement | Fixed fee and one-time service |
+
+## Expected Chat Questions
+
+Run these from the Contracts page after uploading the fixtures:
+
+- Which contracts expire next?
+- What contracts do we have for Björn Eriksen?
+- Do we have an NDA with Microsoft Sweden?
+- Which agreements involve Spotify?
+- Which contracts have renewal or notice deadlines?
+- What is the hourly rate for Spotify?
+- Which contracts have a one-time fee?
+
+## Expected Scope Guard Behavior
+
+These should be rejected with the standard contract-domain boundary message:
+
+- How do I list files in a terminal?
+- What car model should I buy?
+- Give me dating advice.
+
+## Failure Triage
+
+| Symptom | Likely area |
+|---|---|
+| Contract never appears beyond `processing` | Queue/function ingestion |
+| Wrong document type | MAF triage |
+| Missing dates, people, counterparties, or payment facts | Extraction prompt or `ContractFactsExtractor` |
+| Chat ignores a visible normalized fact | `ContractChatAgent` tool choice or `IContractIntelligence` |
+| Chat invents a fact | Prompt/tool result grounding |
+| Correct answer but no document link | Chat references or download URL endpoint |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,104 @@
+# Operations
+
+This is the minimum operating guide for the current production setup:
+
+- Frontend and SWA-managed `/api`: Azure Static Web App `hq-agent-static-web-app`
+- Agents: Azure Function App `hq-agent-function-app`
+- Storage: `hqagentstorage`
+- Tables: `Contracts`, `ContractChatHistory`
+- Queues: `contract-processing`, `contract-processing-poison`
+
+## Quick Health Checks
+
+```bash
+bash infra/scripts/storage-status.sh
+az functionapp function list \
+  --resource-group hq-agent-resource-group \
+  --name hq-agent-function-app \
+  --query "[].name" -o table
+```
+
+Expected active functions:
+
+- `ContractIngestion`
+- `ContractChat`
+
+## Application Insights Queries
+
+Recent ingestion and chat traces:
+
+```kusto
+traces
+| where timestamp > ago(24h)
+| where cloud_RoleName == "hq-agent-function-app"
+| where message has_any ("ContractIngestion", "contract chat", "Tool", "stored", "Rejected out-of-domain")
+| project timestamp, severityLevel, message, operation_Id
+| order by timestamp desc
+```
+
+Follow one contract by correlation ID:
+
+```kusto
+traces
+| where timestamp > ago(7d)
+| where message contains "<correlation-id>"
+| project timestamp, severityLevel, message, operation_Id
+| order by timestamp asc
+```
+
+Failures:
+
+```kusto
+exceptions
+| where timestamp > ago(24h)
+| order by timestamp desc
+```
+
+Guardrail rejections:
+
+```kusto
+traces
+| where timestamp > ago(7d)
+| where message contains "Rejected out-of-domain contract chat message"
+| summarize count() by bin(timestamp, 1d)
+```
+
+## Poison Queue
+
+If ingestion fails repeatedly, Azure Storage will move the message to `contract-processing-poison`.
+
+Inspect queue counts:
+
+```bash
+bash infra/scripts/storage-status.sh
+```
+
+Peek poison messages:
+
+```bash
+az storage message peek \
+  --account-name hqagentstorage \
+  --queue-name contract-processing-poison \
+  --num-messages 5 \
+  --auth-mode login
+```
+
+Do not clear the poison queue until the failed contract correlation IDs have been inspected in Application Insights.
+
+## Safe Maintenance Scripts
+
+| Script | Safe for production? | Use |
+|---|---:|---|
+| `infra/scripts/storage-status.sh` | Yes | Lists container, queue, and table state |
+| `infra/scripts/stream-logs.sh` | Yes | Polls Application Insights traces |
+| `infra/scripts/test-openai-key.sh` | Local only | Tests OpenAI extraction with a fixture PDF |
+| `infra/scripts/clear-storage.sh` | No | Deletes contract blobs, queues, and the `Contracts` table after explicit confirmation |
+
+## Incident Checklist
+
+1. Check GitHub Actions for the latest deployment result.
+2. Run `bash infra/scripts/storage-status.sh`.
+3. If a contract is stuck, find its correlation ID in the UI and run `bash infra/scripts/stream-logs.sh <correlationId>`.
+4. Check `contract-processing-poison` before re-uploading the same document.
+5. If chat fails but ingestion works, verify SWA app setting `CHAT_AGENT_BASE_URL` and Function App setting `CONTRACT_CHAT_FUNCTION_KEY`.
+6. If `/api` works but ingestion does not, verify Function App runtime and that `ContractIngestion` is loaded.

--- a/frontend/src/pages/ContractsPage.vue
+++ b/frontend/src/pages/ContractsPage.vue
@@ -157,6 +157,24 @@
       </footer>
     </div>
 
+    <section v-if="attentionContracts.length" class="attention-strip">
+      <div>
+        <span class="attention-kicker">Needs attention</span>
+        <strong>{{ attentionContracts.length }} contract{{ attentionContracts.length === 1 ? "" : "s" }}</strong>
+      </div>
+      <div class="attention-items">
+        <button
+          v-for="contract in attentionContracts.slice(0, 4)"
+          :key="contract.correlationId"
+          type="button"
+          @click="selectContract(contract)"
+        >
+          <span>{{ contract.fileName || contract.documentType || "Contract" }}</span>
+          <small>{{ lifecycleLabel(contract) }}</small>
+        </button>
+      </div>
+    </section>
+
     <div class="workspace">
       <div class="accordion" :class="{ open: contractsOpen }">
         <button
@@ -229,8 +247,11 @@
                     >
                     <template v-else>
                       {{ contract.documentType || "Document" }} ·
-                      {{ formatDate(contract.uploadedAt) }}
+                      {{ lifecycleLabel(contract) || formatDate(contract.uploadedAt) }}
                     </template>
+                  </div>
+                  <div v-if="paymentLabel(contract)" class="contract-row-payment">
+                    {{ paymentLabel(contract) }}
                   </div>
                 </div>
                 <div class="contract-row-end">
@@ -256,6 +277,15 @@
                     @click.stop="dismissFailed(contract.correlationId)"
                   >
                     Dismiss
+                  </button>
+                  <button
+                    v-if="auth.hasRole('admin') && isPendingReview(contract)"
+                    class="btn-ghost-sm"
+                    type="button"
+                    :disabled="reviewPending === contract.correlationId"
+                    @click.stop="approveContract(contract)"
+                  >
+                    Approve
                   </button>
                 </div>
               </div>
@@ -351,6 +381,7 @@ const detailData = ref(null);
 const detailLoading = ref(false);
 const detailError = ref("");
 const polls = new Map();
+const reviewPending = ref("");
 
 const contractsOpen = ref(false);
 const uploadOpen = ref(false);
@@ -374,6 +405,25 @@ const selectedContract = computed(
   () =>
     contracts.value.find((c) => c.correlationId === selectedId.value) ?? null,
 );
+
+const attentionContracts = computed(() => {
+  const now = new Date();
+  const horizon = new Date(now);
+  horizon.setDate(horizon.getDate() + 120);
+
+  return contracts.value
+    .filter((contract) => isClickable(contract))
+    .filter((contract) => {
+      if (isPendingReview(contract)) return true;
+      const actionDate = lifecycleDate(contract);
+      return actionDate && actionDate >= startOfDay(now) && actionDate <= horizon;
+    })
+    .sort((a, b) => {
+      if (isPendingReview(a) !== isPendingReview(b)) return isPendingReview(a) ? -1 : 1;
+      return (lifecycleDate(a)?.getTime() ?? Number.MAX_SAFE_INTEGER) -
+        (lifecycleDate(b)?.getTime() ?? Number.MAX_SAFE_INTEGER);
+    });
+});
 
 const MAX_SIZE = 20 * 1024 * 1024;
 const ALLOWED_TYPES = [
@@ -466,6 +516,10 @@ function isClickable(contract) {
 }
 
 async function onCardClick(contract) {
+  await selectContract(contract);
+}
+
+async function selectContract(contract) {
   if (!isClickable(contract)) return;
   if (selectedId.value === contract.correlationId) {
     selectedId.value = null;
@@ -659,6 +713,46 @@ function dismissFailed(correlationId) {
   );
 }
 
+async function approveContract(contract) {
+  reviewPending.value = contract.correlationId;
+  try {
+    const res = await fetch("/api/review-contract", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Auth-Token": `Bearer ${auth.getToken()}`,
+      },
+      body: JSON.stringify({
+        correlationId: contract.correlationId,
+        reviewState: "approved",
+      }),
+    });
+    if (!res.ok) throw new Error(`Review failed (${res.status})`);
+    const data = await res.json();
+    const idx = contracts.value.findIndex(
+      (c) => c.correlationId === contract.correlationId,
+    );
+    if (idx >= 0) {
+      contracts.value[idx] = {
+        ...contracts.value[idx],
+        status: data.status,
+        reviewState: data.reviewState,
+        reviewedAt: data.reviewedAt,
+        reviewedBy: data.reviewedBy,
+      };
+    }
+  } catch {
+    chatMessages.value.push({
+      id: crypto.randomUUID(),
+      role: "assistant",
+      content: "I could not approve that contract review. Please try again.",
+      error: true,
+    });
+  } finally {
+    reviewPending.value = "";
+  }
+}
+
 function onDrop(e) {
   isDragging.value = false;
   uploadFiles(Array.from(e.dataTransfer.files));
@@ -724,6 +818,45 @@ function formatDate(iso) {
 
 function flatFields(fields) {
   return !fields || typeof fields !== "object" ? {} : fields;
+}
+
+function isPendingReview(contract) {
+  return (
+    contract.status === "pending_review" ||
+    contract.reviewState === "pending_review"
+  );
+}
+
+function lifecycleDate(contract) {
+  const date =
+    contract.noticeDeadline ??
+    contract.expiryDate ??
+    contract.assignmentEndDate;
+  return date ? startOfDay(new Date(date)) : null;
+}
+
+function lifecycleLabel(contract) {
+  if (isPendingReview(contract)) return "Pending review";
+  if (contract.noticeDeadline) return `Notice by ${formatDate(contract.noticeDeadline)}`;
+  if (contract.expiryDate) return `Expires ${formatDate(contract.expiryDate)}`;
+  if (contract.assignmentEndDate) return `Assignment ends ${formatDate(contract.assignmentEndDate)}`;
+  return "";
+}
+
+function paymentLabel(contract) {
+  if (!contract.paymentAmount) return "";
+  const amount = new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: 2,
+  }).format(contract.paymentAmount);
+  const currency = contract.paymentCurrency || "";
+  const unit = contract.paymentUnit && contract.paymentUnit !== "one_time"
+    ? `/${contract.paymentUnit}`
+    : "";
+  return `${amount} ${currency}${unit}`.trim();
+}
+
+function startOfDay(date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }
 </script>
 
@@ -1124,6 +1257,68 @@ textarea::placeholder {
   gap: 0.9rem;
 }
 
+.attention-strip {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid #d7cdbf;
+  border-radius: 12px;
+  background: #fffaf0;
+}
+
+.attention-strip strong {
+  display: block;
+  margin-top: 0.1rem;
+  font-size: 0.95rem;
+}
+
+.attention-kicker {
+  color: #8a5f11;
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.attention-items {
+  display: flex;
+  gap: 0.5rem;
+  overflow: auto;
+}
+
+.attention-items button {
+  min-width: 11rem;
+  max-width: 16rem;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid #e8d6aa;
+  border-radius: 8px;
+  background: #fff;
+  color: var(--ink);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.attention-items span,
+.attention-items small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.attention-items span {
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.attention-items small {
+  margin-top: 0.12rem;
+  color: #8a5f11;
+  font-size: 0.72rem;
+}
+
 .workspace-right {
   display: none;
 }
@@ -1260,6 +1455,13 @@ textarea::placeholder {
   font-size: 0.76rem;
 }
 
+.contract-row-payment {
+  margin-top: 0.18rem;
+  color: var(--accent);
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
 .contract-row-end {
   display: flex;
   align-items: center;
@@ -1299,6 +1501,11 @@ textarea::placeholder {
   color: var(--muted);
   padding: 0.25rem 0.55rem;
   cursor: pointer;
+}
+
+.btn-ghost-sm:disabled {
+  opacity: 0.55;
+  cursor: default;
 }
 
 .dropzone {
@@ -1414,8 +1621,18 @@ textarea::placeholder {
   }
 
   .chat-suggestions,
-  .workspace {
+  .workspace,
+  .attention-strip {
     grid-template-columns: 1fr;
+  }
+
+  .attention-items {
+    flex-direction: column;
+  }
+
+  .attention-items button {
+    max-width: none;
+    width: 100%;
   }
 
   .message,

--- a/infra/scripts/clear-storage.sh
+++ b/infra/scripts/clear-storage.sh
@@ -6,6 +6,12 @@ set -euo pipefail
 STORAGE_ACCOUNT="hqagentstorage"
 RESOURCE_GROUP="hq-agent-resource-group"
 
+if [ "${HQ_AGENT_CONFIRM_CLEAR_STORAGE:-}" != "DELETE_CONTRACT_TEST_DATA" ]; then
+  echo "This deletes all blobs in contracts, clears contract queues, and deletes the Contracts table."
+  echo "Set HQ_AGENT_CONFIRM_CLEAR_STORAGE=DELETE_CONTRACT_TEST_DATA to continue." >&2
+  exit 1
+fi
+
 echo "Fetching storage key..."
 KEY=$(az storage account keys list \
   --account-name "$STORAGE_ACCOUNT" \

--- a/infra/scripts/storage-status.sh
+++ b/infra/scripts/storage-status.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Lists the current production storage objects that matter for HQ Agent.
+set -euo pipefail
+
+STORAGE_ACCOUNT="hqagentstorage"
+RESOURCE_GROUP="hq-agent-resource-group"
+
+KEY=$(az storage account keys list \
+  --account-name "$STORAGE_ACCOUNT" \
+  --resource-group "$RESOURCE_GROUP" \
+  --query "[0].value" -o tsv)
+
+ARGS=(--account-name "$STORAGE_ACCOUNT" --account-key "$KEY")
+
+echo "Storage account: $STORAGE_ACCOUNT"
+echo ""
+
+echo "Containers"
+az storage container list "${ARGS[@]}" \
+  --query "[].{name:name, publicAccess:properties.publicAccess}" -o table
+
+echo ""
+echo "Queues"
+for QUEUE in contract-processing contract-processing-poison; do
+  EXISTS=$(az storage queue exists "${ARGS[@]}" --name "$QUEUE" --query "exists" -o tsv 2>/dev/null || echo "false")
+  if [ "$EXISTS" = "true" ]; then
+    PEEK=$(az storage message peek "${ARGS[@]}" --queue-name "$QUEUE" --num-messages 1 --query "length(@)" -o tsv 2>/dev/null || echo "unknown")
+    if [ "$PEEK" = "0" ]; then
+      echo "$QUEUE: exists, no visible messages"
+    elif [ "$PEEK" = "1" ]; then
+      echo "$QUEUE: exists, at least one visible message"
+    else
+      echo "$QUEUE: exists"
+    fi
+  else
+    echo "$QUEUE: missing"
+  fi
+done
+
+echo ""
+echo "Tables"
+for TABLE in Contracts ContractChatHistory; do
+  EXISTS=$(az storage table exists "${ARGS[@]}" --name "$TABLE" --query "exists" -o tsv 2>/dev/null || echo "false")
+  echo "$TABLE: $EXISTS"
+done

--- a/infra/scripts/stream-logs.sh
+++ b/infra/scripts/stream-logs.sh
@@ -18,9 +18,9 @@
 #
 # Expected sequence for a healthy upload:
 #   [ContractIngestion]         "ContractIngestion triggered for {correlationId}"
-#   [OpenAIContractWorkflow]    "Processing contract {correlationId} — {blobName}"
-#   [OpenAIContractWorkflow]    "PDF text extracted: {charCount} chars"
-#   [OpenAIContractWorkflow]    "Workflow complete for {correlationId}"
+#   [ContractOrchestratorAgent] "Processing contract {correlationId} — {blobName}"
+#   [DocumentTextExtractor]     "PDF text extracted: {charCount} chars"
+#   [ContractOrchestratorAgent] "Workflow output for {correlationId}: ..."
 #   [ContractIngestion]         "Contract {correlationId} stored — type:... pendingReview:... model:..."
 
 set -euo pipefail

--- a/shared/HqAgent.Shared.Tests/ContractFactsExtractorTests.cs
+++ b/shared/HqAgent.Shared.Tests/ContractFactsExtractorTests.cs
@@ -20,6 +20,9 @@ public class ContractFactsExtractorTests
               "assignmentEndDate": "2026-10-31",
               "noticePeriodDays": 30,
               "autoRenewal": false,
+              "hourlyRate": 1500,
+              "currency": "SEK",
+              "paymentTerms": "30 days net",
               "riskFlags": ["Customer may terminate for convenience"]
             }
             """,
@@ -34,6 +37,11 @@ public class ContractFactsExtractorTests
         Assert.Equal(new DateTime(2026, 10, 1), facts.NoticeDeadline);
         Assert.Equal(30, facts.NoticePeriodDays);
         Assert.False(facts.AutoRenewal);
+        Assert.Equal(1500m, facts.PaymentAmount);
+        Assert.Equal("SEK", facts.PaymentCurrency);
+        Assert.Equal("hour", facts.PaymentUnit);
+        Assert.Equal("rate", facts.PaymentType);
+        Assert.Equal("30 days net", facts.PaymentTerms);
         Assert.Contains("Bjorn Eriksen", facts.PeopleMentioned);
         Assert.Contains("Acme AB", facts.CounterpartyNames);
         Assert.Contains("Customer may terminate for convenience", facts.RiskFlags);
@@ -66,5 +74,36 @@ public class ContractFactsExtractorTests
         Assert.Contains("Contoso Ltd", facts.CounterpartyNames);
         Assert.Contains("Bjorn Eriksen", facts.PeopleMentioned);
         Assert.Contains("expiryDate", facts.MissingFields);
+    }
+
+    [Fact]
+    public void ExtractsOneTimeFeeFacts()
+    {
+        var extraction = new ExtractionResult(
+            "Inspirational Talk Agreement",
+            0.93,
+            """
+            {
+              "customer": "Nox Consulting",
+              "supplier": "Be Concrete AB",
+              "peopleMentioned": ["Björn Eriksen"],
+              "eventDate": "2026-04-20",
+              "oneTimeFee": "20000 SEK",
+              "currency": "SEK",
+              "paymentTerms": "Due after delivery"
+            }
+            """,
+            0.88,
+            "gpt-4.1",
+            false);
+
+        var facts = ContractFactsExtractor.Extract(extraction);
+
+        Assert.Equal("Nox Consulting", facts.PrimaryCounterparty);
+        Assert.Equal(20000m, facts.PaymentAmount);
+        Assert.Equal("SEK", facts.PaymentCurrency);
+        Assert.Equal("one_time", facts.PaymentUnit);
+        Assert.Equal("fixed_fee", facts.PaymentType);
+        Assert.Contains("Björn Eriksen", facts.PeopleMentioned);
     }
 }

--- a/shared/HqAgent.Shared/Models/ContractExtractionEntity.cs
+++ b/shared/HqAgent.Shared/Models/ContractExtractionEntity.cs
@@ -34,6 +34,11 @@ public class ContractExtractionEntity : ITableEntity
     public string   CustomerName          { get; set; } = string.Empty;
     public DateTime? AssignmentStartDate  { get; set; }
     public DateTime? AssignmentEndDate    { get; set; }
+    public double?  PaymentAmount         { get; set; }
+    public string   PaymentCurrency       { get; set; } = string.Empty;
+    public string   PaymentUnit           { get; set; } = string.Empty;
+    public string   PaymentType           { get; set; } = string.Empty;
+    public string   PaymentTerms          { get; set; } = string.Empty;
     public string   RiskFlags             { get; set; } = string.Empty;
     public string   MissingFields         { get; set; } = string.Empty;
 
@@ -43,4 +48,8 @@ public class ContractExtractionEntity : ITableEntity
     public string    ModelUsed            { get; set; } = string.Empty;
     public DateTime? ProcessedAt         { get; set; }
     public string    Status              { get; set; } = string.Empty;
+    public string    ReviewState          { get; set; } = string.Empty;
+    public DateTime? ReviewedAt          { get; set; }
+    public string    ReviewedBy          { get; set; } = string.Empty;
+    public string    ReviewNote          { get; set; } = string.Empty;
 }

--- a/shared/HqAgent.Shared/Models/ContractFactsExtractor.cs
+++ b/shared/HqAgent.Shared/Models/ContractFactsExtractor.cs
@@ -56,6 +56,32 @@ public static class ContractFactsExtractor
         "riskFlags", "risks", "keyRisks"
     ];
 
+    private static readonly string[] PaymentAmountKeys =
+    [
+        "paymentAmount", "amount", "fee", "fixedFee", "oneTimeFee", "contractValue",
+        "hourlyRate", "dailyRate", "monthlyFee", "licenseFee", "subscriptionFee", "rate"
+    ];
+
+    private static readonly string[] PaymentCurrencyKeys =
+    [
+        "paymentCurrency", "currency", "feeCurrency", "rateCurrency", "contractCurrency"
+    ];
+
+    private static readonly string[] PaymentUnitKeys =
+    [
+        "paymentUnit", "rateUnit", "billingUnit", "unit", "priceUnit"
+    ];
+
+    private static readonly string[] PaymentTypeKeys =
+    [
+        "paymentType", "feeType", "pricingModel", "commercialModel", "billingModel"
+    ];
+
+    private static readonly string[] PaymentTermsKeys =
+    [
+        "paymentTerms", "invoicingTerms", "invoiceTerms", "billingTerms"
+    ];
+
     public static NormalizedContractFacts Extract(ExtractionResult extraction)
     {
         if (string.IsNullOrWhiteSpace(extraction.ExtractedFields))
@@ -82,6 +108,16 @@ public static class ContractFactsExtractor
             var people = FindStrings(root, PersonKeys);
             var riskFlags = FindStrings(root, RiskKeys);
             var missingFields = BuildMissingFields(expiryDate, counterparties, people);
+            var paymentAmount = FindDecimal(root, PaymentAmountKeys);
+            var paymentCurrency = FirstNonEmpty(FindStrings(root, PaymentCurrencyKeys));
+            var paymentUnit = FirstNonEmpty(FindStrings(root, PaymentUnitKeys));
+            var paymentType = FirstNonEmpty(FindStrings(root, PaymentTypeKeys));
+
+            if (string.IsNullOrWhiteSpace(paymentUnit))
+                paymentUnit = InferPaymentUnit(root);
+
+            if (string.IsNullOrWhiteSpace(paymentType))
+                paymentType = InferPaymentType(root, paymentUnit);
 
             return new NormalizedContractFacts(
                 effectiveDate,
@@ -95,6 +131,11 @@ public static class ContractFactsExtractor
                 customerName,
                 FindDate(root, AssignmentStartDateKeys),
                 FindDate(root, AssignmentEndDateKeys),
+                paymentAmount,
+                paymentCurrency,
+                paymentUnit,
+                paymentType,
+                FirstNonEmpty(FindStrings(root, PaymentTermsKeys)),
                 riskFlags,
                 missingFields);
         }
@@ -105,7 +146,7 @@ public static class ContractFactsExtractor
     }
 
     private static NormalizedContractFacts Empty(IReadOnlyList<string>? missingFields = null) =>
-        new(null, null, null, null, null, "", [], [], "", null, null, [], missingFields ?? []);
+        new(null, null, null, null, null, "", [], [], "", null, null, null, "", "", "", "", [], missingFields ?? []);
 
     private static IReadOnlyList<string> BuildMissingFields(
         DateTime? expiryDate,
@@ -139,6 +180,33 @@ public static class ContractFactsExtractor
                 return number;
             if (value.ValueKind == JsonValueKind.String &&
                 int.TryParse(value.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out number))
+                return number;
+        }
+
+        return null;
+    }
+
+    private static decimal? FindDecimal(JsonElement root, IReadOnlyCollection<string> keys)
+    {
+        foreach (var value in FindValues(root, keys))
+        {
+            if (value.ValueKind == JsonValueKind.Number && value.TryGetDecimal(out var number))
+                return number;
+
+            if (value.ValueKind != JsonValueKind.String)
+                continue;
+
+            var text = value.GetString();
+            if (string.IsNullOrWhiteSpace(text))
+                continue;
+
+            var cleaned = NormalizeNumberText(text);
+
+            if (decimal.TryParse(
+                    cleaned,
+                    NumberStyles.Number,
+                    CultureInfo.InvariantCulture,
+                    out number))
                 return number;
         }
 
@@ -246,4 +314,43 @@ public static class ContractFactsExtractor
 
     private static string NormalizeWhitespace(string value) =>
         string.Join(" ", value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+    private static string NormalizeNumberText(string value)
+    {
+        var cleaned = new string(value
+            .Where(c => char.IsDigit(c) || c is '.' or ',' or '-')
+            .ToArray());
+
+        var lastDot = cleaned.LastIndexOf('.');
+        var lastComma = cleaned.LastIndexOf(',');
+        var decimalSeparator = Math.Max(lastDot, lastComma);
+        if (decimalSeparator < 0)
+            return cleaned;
+
+        var digitsAfter = cleaned.Length - decimalSeparator - 1;
+        if (digitsAfter == 3 && cleaned.Count(c => c is '.' or ',') == 1)
+            return cleaned.Replace(".", "").Replace(",", "");
+
+        var integer = cleaned[..decimalSeparator].Replace(".", "").Replace(",", "");
+        var decimals = cleaned[(decimalSeparator + 1)..].Replace(".", "").Replace(",", "");
+        return $"{integer}.{decimals}";
+    }
+
+    private static string InferPaymentUnit(JsonElement root)
+    {
+        if (FindDecimal(root, ["hourlyRate"]) is not null) return "hour";
+        if (FindDecimal(root, ["dailyRate"]) is not null) return "day";
+        if (FindDecimal(root, ["monthlyFee"]) is not null) return "month";
+        if (FindDecimal(root, ["oneTimeFee", "fixedFee"]) is not null) return "one_time";
+        return "";
+    }
+
+    private static string InferPaymentType(JsonElement root, string paymentUnit)
+    {
+        if (FindDecimal(root, ["oneTimeFee", "fixedFee"]) is not null || paymentUnit == "one_time")
+            return "fixed_fee";
+        if (FindDecimal(root, ["hourlyRate", "dailyRate", "monthlyFee", "rate"]) is not null)
+            return "rate";
+        return "";
+    }
 }

--- a/shared/HqAgent.Shared/Models/NormalizedContractFacts.cs
+++ b/shared/HqAgent.Shared/Models/NormalizedContractFacts.cs
@@ -12,5 +12,10 @@ public record NormalizedContractFacts(
     string CustomerName,
     DateTime? AssignmentStartDate,
     DateTime? AssignmentEndDate,
+    decimal? PaymentAmount,
+    string PaymentCurrency,
+    string PaymentUnit,
+    string PaymentType,
+    string PaymentTerms,
     IReadOnlyList<string> RiskFlags,
     IReadOnlyList<string> MissingFields);

--- a/shared/HqAgent.Shared/Storage/TableStorageService.cs
+++ b/shared/HqAgent.Shared/Storage/TableStorageService.cs
@@ -46,12 +46,18 @@ public class TableStorageService
             CustomerName     = facts.CustomerName,
             AssignmentStartDate = facts.AssignmentStartDate,
             AssignmentEndDate = facts.AssignmentEndDate,
+            PaymentAmount    = facts.PaymentAmount.HasValue ? (double)facts.PaymentAmount.Value : null,
+            PaymentCurrency  = facts.PaymentCurrency,
+            PaymentUnit      = facts.PaymentUnit,
+            PaymentType      = facts.PaymentType,
+            PaymentTerms     = facts.PaymentTerms,
             RiskFlags        = JsonSerializer.Serialize(facts.RiskFlags),
             MissingFields    = JsonSerializer.Serialize(facts.MissingFields),
             Fields           = JsonSerializer.Serialize(extraction),
             ModelUsed        = extraction.ModelUsed,
             ProcessedAt      = DateTime.UtcNow,
             Status           = extraction.PendingReview ? "pending_review" : "completed",
+            ReviewState      = extraction.PendingReview ? "pending_review" : "approved_by_extraction",
         };
 
         var table = _client.GetTableClient(TableName);
@@ -77,6 +83,7 @@ public class TableStorageService
             UploadedAt   = message.UploadedAt,
             ProcessedAt  = DateTime.UtcNow,
             Status       = "failed",
+            ReviewState  = "failed",
         };
 
         var table = _client.GetTableClient(TableName);
@@ -130,5 +137,40 @@ public class TableStorageService
 
         results.Sort((a, b) => b.UploadedAt.CompareTo(a.UploadedAt));
         return results;
+    }
+
+    public async Task<ContractExtractionEntity?> UpdateReviewAsync(
+        string            correlationId,
+        string            reviewState,
+        string            reviewedBy,
+        string?           reviewNote,
+        CancellationToken ct = default)
+    {
+        var table = _client.GetTableClient(TableName);
+        ContractExtractionEntity entity;
+        try
+        {
+            entity = (await table.GetEntityAsync<ContractExtractionEntity>(
+                correlationId, "extraction", cancellationToken: ct)).Value;
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return null;
+        }
+
+        entity.ReviewState = reviewState;
+        entity.Status = reviewState is "approved" or "approved_by_extraction"
+            ? "completed"
+            : "pending_review";
+        entity.ReviewedAt = DateTime.UtcNow;
+        entity.ReviewedBy = reviewedBy;
+        entity.ReviewNote = reviewNote ?? "";
+
+        await table.UpsertEntityAsync(entity, TableUpdateMode.Replace, ct);
+        _logger.LogInformation(
+            "Updated contract review — correlationId:{CorrelationId} reviewState:{ReviewState} reviewedBy:{ReviewedBy}",
+            correlationId, reviewState, reviewedBy);
+
+        return entity;
     }
 }


### PR DESCRIPTION
## What changed

Implements Chunks 1-4 while leaving future Sales/HR discovery for later.

- Extends the durable contract fact model with normalized payment fields and review metadata.
- Adds admin review approval through `/api/review-contract` and surfaces pending review/lifecycle attention in the Contracts UI.
- Updates extraction guidance for NDA, consulting, software/licence, service/customer, and one-time engagement contracts.
- Documents the `IContractIntelligence` capability boundary, cross-domain call pattern, MAF checklist, evaluation set, and operations playbook.
- Adds safe storage inspection and makes destructive storage cleanup require explicit confirmation.
- Adds PR validation for the agents Function App build while keeping agent deployment limited to `main`.

## Issues

Closes #28
Closes #29
Closes #30
Closes #31
Closes #33
Closes #34
Closes #35
Closes #36
Closes #37
Closes #38

## Validation

- `dotnet test shared/HqAgent.Shared.Tests/HqAgent.Shared.Tests.csproj`
- `dotnet build api/HqAgentApi.csproj --configuration Release`
- `dotnet build agents/agents.csproj --configuration Release`
- `npm run build` in `frontend/`
- `bash infra/scripts/storage-status.sh`
